### PR TITLE
cats-effect version workaround

### DIFF
--- a/default.json
+++ b/default.json
@@ -14,4 +14,10 @@
   "lockFileMaintenance": {
     "enabled": true
   }
+  "packageRules": [
+    {
+      "matchPackageNames": ["org.typelevel:cats-effect"],
+      "versioning": "regex:^(?<major>\\d+)(\\.(?<minor>\\d+))(\\.(?<patch>\\d+))$"
+    }  
+  ]
 }


### PR DESCRIPTION
Looks like versions ending with extra suffix are snapshot/preview versions, let's exclude them by default.
https://mvnrepository.com/artifact/org.typelevel/cats-effect

Taken from https://github.com/cognitedata/scala-microservice/pull/299