### PR TITLE
Update scala cats-effect customization

### DIFF
--- a/default.json
+++ b/default.json
@@ -16,7 +16,7 @@
   },
   "packageRules": [
     {
-      "matchPackageNames": ["org.typelevel:cats-effect"],
+      "matchPackagePrefixes": ["org.typelevel:cats-effect"],
       "versioning": "regex:^(?<major>\\d+)(\\.(?<minor>\\d+))(\\.(?<patch>\\d+))$"
     }  
   ]


### PR DESCRIPTION
There are several packages that have "snapshot" suffix like `org.typelevel:cats-effect-laws:3.6-1f95fd7` or `org.typelevel:cats-effect-testkit:3.6-1f95fd7` Let's extend customization to them too