### PR TITLE
Avoid snapshot update for scala fs2 too

### DIFF
--- a/default.json
+++ b/default.json
@@ -16,7 +16,7 @@
   },
   "packageRules": [
     {
-      "matchPackagePrefixes": ["org.typelevel:cats-effect"],
+      "matchPackagePrefixes": ["org.typelevel:cats-effect", "co.fs2:fs2"],
       "versioning": "regex:^(?<major>\\d+)(\\.(?<minor>\\d+))(\\.(?<patch>\\d+))$"
     }  
   ]


### PR DESCRIPTION
cats-effect as well as fs2 have snapshot versions and renovate suggests them if we don't override versioning scheme here
```
co.fs2:fs2-core (source) 	minor 3.3.0 -> 3.8-1580d81
```
Let's cover fs2 here too to disable such updates by default