### PR TITLE
Apply rebaseWhen: "conflicted"

### DIFF
--- a/default.json
+++ b/default.json
@@ -9,6 +9,7 @@
   "automerge": false,
   "platformAutomerge": true,
   "dependencyDashboardApproval": true,
+  "rebaseWhen": "conflicted",
   "pre-commit": {
     "enabled": true
   },


### PR DESCRIPTION
Rebasing can discard Github reviews or policy-bot risk reviews, while "update branch" button or merge/merge queue can keep reviews and be mergeable (depending on exact repo settings).
When there's a conflict rebase is good because re-review will be needed anyway for most repos (risk-review always, github review depending on repo settings but most often latest diff needs to be reviewed)