### PR TITLE
Enforce minimumReleaseAge

### DIFF
--- a/default.json
+++ b/default.json
@@ -4,7 +4,6 @@
   "ignorePaths": ["**/node_modules/**"],
   "onboardingConfigFileName": ".github/renovate.json",
   "minimumReleaseAge": "7 days",
-  "minimumReleaseAgeBehaviour": "timestamp-optional",
   "automerge": false,
   "platformAutomerge": true,
   "dependencyDashboardApproval": false,


### PR DESCRIPTION
Removed the minimumReleaseAgeBehaviour configuration.

This is unsafe in the presence of supply chain attacks.