### PR TITLE
Disable all updates except security fixes

### DIFF
--- a/default.json
+++ b/default.json
@@ -4,6 +4,11 @@
   "ignorePaths": ["**/node_modules/**"],
   "onboardingConfigFileName": ".github/renovate.json",
   "minimumReleaseAge": "7 days",
+  "enabled": false,
+  "vulnerabilityAlerts": {
+    "enabled": true
+  },
+  "osvVulnerabilityAlerts": true,
   "automerge": false,
   "platformAutomerge": true,
   "dependencyDashboardApproval": false,


### PR DESCRIPTION
To reduce the risk of supply chain attacks, we want Renovate to only create PRs for security fixes. This PR disables updates that are not security fixes.

* "enabled": false — suppresses all routine dependency update PRs

* "vulnerabilityAlerts": { "enabled": true } — opens PRs for known CVEs

* "osvVulnerabilityAlerts": true — pulls vulnerability data from OSV in addition to the GitHub Advisory Database, giving broader coverage.