### PR TITLE
Wait until minimumReleaseAge has lapsed before creating PRs

### DIFF
--- a/default.json
+++ b/default.json
@@ -4,7 +4,7 @@
   "ignorePaths": ["**/node_modules/**"],
   "onboardingConfigFileName": ".github/renovate.json",
   "minimumReleaseAge": "7 days",
-  "enabled": false,
+  "prCreation": "not-pending",
   "vulnerabilityAlerts": {
     "enabled": true
   },


### PR DESCRIPTION
Follow-up to https://github.com/cognitedata/renovate-config-public/pull/56.

`"enabled": false` in https://github.com/cognitedata/renovate-config-public/pull/56 disabled Renovate completely. This PR removes that setting.

The way to make Renovate create PRs only after `minimumReleaseAge` is to set `"prCreation": "not-pending"`. The stability-days check stays pending until `minimumReleaseAge` is reached.

Tested with https://github.com/cognitedatadevelopment/security-test-renovate.

One issue we will have is that for dependencies without a timestamp the upgrade will stay in "pending" status forever, requiring manual review.