### PR TITLE
use dummy timestamps on cluster ring datasource versions

### DIFF
--- a/integers_0_to_5/integers-0.json
+++ b/integers_0_to_5/integers-0.json
@@ -1,10 +1,12 @@
 {
   "releases": [
     {
-      "version": "0"
+      "version": "0",
+      "releaseTimestamp": "2025-01-01T00:00Z"
     },
     {
-      "version": "1"
+      "version": "1",
+      "releaseTimestamp": "2025-01-01T00:00Z"
     }
   ]
 }

--- a/integers_0_to_5/integers-1.json
+++ b/integers_0_to_5/integers-1.json
@@ -1,10 +1,12 @@
 {
   "releases": [
     {
-      "version": "1"
+      "version": "1",
+      "releaseTimestamp": "2025-01-01T00:00Z"
     },
     {
-      "version": "2"
+      "version": "2",
+      "releaseTimestamp": "2025-01-01T00:00Z"
     }
   ]
 }

--- a/integers_0_to_5/integers-2.json
+++ b/integers_0_to_5/integers-2.json
@@ -1,10 +1,12 @@
 {
   "releases": [
     {
-      "version": "2"
+      "version": "2",
+      "releaseTimestamp": "2025-01-01T00:00Z"
     },
     {
-      "version": "3"
+      "version": "3",
+      "releaseTimestamp": "2025-01-01T00:00Z"
     }
   ]
 }

--- a/integers_0_to_5/integers-3.json
+++ b/integers_0_to_5/integers-3.json
@@ -1,10 +1,12 @@
 {
   "releases": [
     {
-      "version": "3"
+      "version": "3",
+      "releaseTimestamp": "2025-01-01T00:00Z"
     },
     {
-      "version": "4"
+      "version": "4",
+      "releaseTimestamp": "2025-01-01T00:00Z"
     }
   ]
 }

--- a/integers_0_to_5/integers-4.json
+++ b/integers_0_to_5/integers-4.json
@@ -1,10 +1,12 @@
 {
   "releases": [
     {
-      "version": "4"
+      "version": "4",
+      "releaseTimestamp": "2025-01-01T00:00Z"
     },
     {
-      "version": "5"
+      "version": "5",
+      "releaseTimestamp": "2025-01-01T00:00Z"
     }
   ]
 }

--- a/integers_0_to_5/integers-5.json
+++ b/integers_0_to_5/integers-5.json
@@ -1,7 +1,8 @@
 {
   "releases": [
     {
-      "version": "5"
+      "version": "5",
+      "releaseTimestamp": "2025-01-01T00:00Z"
     }
   ]
 }


### PR DESCRIPTION
this will allow us to remove timestamp-optional behaviour, so we avoid renovate warnings